### PR TITLE
Fix spelling of 'states' in headers

### DIFF
--- a/CY8CKIT-062-BLE Pioneer Kit/CE218133_EINK_CapSense/CE218133_EINK_CapSense.cydsn/cy_eink_psoc_interface.h
+++ b/CY8CKIT-062-BLE Pioneer Kit/CE218133_EINK_CapSense/CE218133_EINK_CapSense.cydsn/cy_eink_psoc_interface.h
@@ -63,7 +63,7 @@
 #define CY_EINK_BYTE_SIZE      (uint8_t)(0x08u)
 #define CY_EINK_SINGLE_BYTE    (uint8_t)(0x01u)
 
-/* Definitions of pin sates */
+/* Definitions of pin states */
 #define CY_EINK_PIN_LOW        (uint8_t)(0x00u)
 #define CY_EINK_PIN_HIGH       (uint8_t)(0x01u)
 

--- a/CY8CKIT-062-BLE Pioneer Kit/CE218135_BLE_Proximity/CE218135_BLE_Proximity.cydsn/cy_eink_psoc_interface.h
+++ b/CY8CKIT-062-BLE Pioneer Kit/CE218135_BLE_Proximity/CE218135_BLE_Proximity.cydsn/cy_eink_psoc_interface.h
@@ -63,7 +63,7 @@
 #define CY_EINK_BYTE_SIZE      (uint8_t)(0x08u)
 #define CY_EINK_SINGLE_BYTE    (uint8_t)(0x01u)
 
-/* Definitions of pin sates */
+/* Definitions of pin states */
 #define CY_EINK_PIN_LOW        (uint8_t)(0x00u)
 #define CY_EINK_PIN_HIGH       (uint8_t)(0x01u)
 

--- a/CY8CKIT-062-BLE Pioneer Kit/CE220167_BLE_UI/CE220167_BLE_UI.cydsn/cy_eink_psoc_interface.h
+++ b/CY8CKIT-062-BLE Pioneer Kit/CE220167_BLE_UI/CE220167_BLE_UI.cydsn/cy_eink_psoc_interface.h
@@ -63,7 +63,7 @@
 #define CY_EINK_BYTE_SIZE      (uint8_t)(0x08u)
 #define CY_EINK_SINGLE_BYTE    (uint8_t)(0x01u)
 
-/* Definitions of pin sates */
+/* Definitions of pin states */
 #define CY_EINK_PIN_LOW        (uint8_t)(0x00u)
 #define CY_EINK_PIN_HIGH       (uint8_t)(0x01u)
 

--- a/CY8CKIT-062-BLE Pioneer Kit/CE220186_RTC_CTS/CE220186_RTC_CTS.cydsn/cy_eink_psoc_interface.h
+++ b/CY8CKIT-062-BLE Pioneer Kit/CE220186_RTC_CTS/CE220186_RTC_CTS.cydsn/cy_eink_psoc_interface.h
@@ -63,7 +63,7 @@
 #define CY_EINK_BYTE_SIZE      (uint8_t)(0x08u)
 #define CY_EINK_SINGLE_BYTE    (uint8_t)(0x01u)
 
-/* Definitions of pin sates */
+/* Definitions of pin states */
 #define CY_EINK_PIN_LOW        (uint8_t)(0x00u)
 #define CY_EINK_PIN_HIGH       (uint8_t)(0x01u)
 

--- a/CY8CKIT-062-BLE Pioneer Kit/CE220335_BLE_Eddystone/CE220335_BLE_Eddystone.cydsn/cy_eink_psoc_interface.h
+++ b/CY8CKIT-062-BLE Pioneer Kit/CE220335_BLE_Eddystone/CE220335_BLE_Eddystone.cydsn/cy_eink_psoc_interface.h
@@ -63,7 +63,7 @@
 #define CY_EINK_BYTE_SIZE      (uint8_t)(0x08u)
 #define CY_EINK_SINGLE_BYTE    (uint8_t)(0x01u)
 
-/* Definitions of pin sates */
+/* Definitions of pin states */
 #define CY_EINK_PIN_LOW        (uint8_t)(0x00u)
 #define CY_EINK_PIN_HIGH       (uint8_t)(0x01u)
 

--- a/CY8CKIT-062-BLE Pioneer Kit/CE220567_BLE_Thermometer/CE220567_BLE_Thermometer/CE220567_BLE_Thermometer.cydsn/cy_eink_psoc_interface.h
+++ b/CY8CKIT-062-BLE Pioneer Kit/CE220567_BLE_Thermometer/CE220567_BLE_Thermometer/CE220567_BLE_Thermometer.cydsn/cy_eink_psoc_interface.h
@@ -62,7 +62,7 @@
 #define CY_EINK_BYTE_SIZE      (uint8_t)(0x08u)
 #define CY_EINK_SINGLE_BYTE    (uint8_t)(0x01u)
 
-/* Definitions of pin sates */
+/* Definitions of pin states */
 #define CY_EINK_PIN_LOW        (uint8_t)(0x00u)
 #define CY_EINK_PIN_HIGH       (uint8_t)(0x01u)
 

--- a/CY8CKIT-062-BLE Pioneer Kit/CE220675_MotionSensor/CE220675_MotionSensor.cydsn/cy_eink_psoc_interface.h
+++ b/CY8CKIT-062-BLE Pioneer Kit/CE220675_MotionSensor/CE220675_MotionSensor.cydsn/cy_eink_psoc_interface.h
@@ -63,7 +63,7 @@
 #define CY_EINK_BYTE_SIZE      (uint8_t)(0x08u)
 #define CY_EINK_SINGLE_BYTE    (uint8_t)(0x01u)
 
-/* Definitions of pin sates */
+/* Definitions of pin states */
 #define CY_EINK_PIN_LOW        (uint8_t)(0x00u)
 #define CY_EINK_PIN_HIGH       (uint8_t)(0x01u)
 


### PR DESCRIPTION
Just fixing some typos.